### PR TITLE
hash: add blake2b/blake3

### DIFF
--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -8,14 +8,16 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
-	"github.com/jzelinskie/whirlpool"
-	"golang.org/x/crypto/sha3"
 	"hash"
 	"hash/adler32"
 	"hash/crc32"
 	"hash/fnv"
 	"math/rand"
 	"testing"
+
+	"github.com/jzelinskie/whirlpool"
+	"golang.org/x/crypto/blake2b"
+	"golang.org/x/crypto/sha3"
 )
 
 func benchmarkHashAlgo(b *testing.B, h hash.Hash) {
@@ -31,6 +33,22 @@ func benchmarkHashAlgo(b *testing.B, h hash.Hash) {
 
 func BenchmarkAdler32(b *testing.B) {
 	benchmarkHashAlgo(b, adler32.New())
+}
+
+func BenchmarkBlake2b256(b *testing.B) {
+	h, err := blake2b.New256(nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchmarkHashAlgo(b, h)
+}
+
+func BenchmarkBlake2b512(b *testing.B) {
+	h, err := blake2b.New512(nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchmarkHashAlgo(b, h)
 }
 
 func BenchmarkCRC32(b *testing.B) {

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/jzelinskie/whirlpool"
+	"github.com/zeebo/blake3"
 	"golang.org/x/crypto/blake2b"
 	"golang.org/x/crypto/sha3"
 )
@@ -49,6 +50,10 @@ func BenchmarkBlake2b512(b *testing.B) {
 		b.Fatal(err)
 	}
 	benchmarkHashAlgo(b, h)
+}
+
+func BenchmarkBlake3256(b *testing.B) {
+	benchmarkHashAlgo(b, blake3.New())
 }
 
 func BenchmarkCRC32(b *testing.B) {


### PR DESCRIPTION
I was wondering how the stdlib implementations of SHA-2 compare with some implementations of [blake2b](https://blake2.net/) and [blake3](https://github.com/BLAKE3-team/BLAKE3).  These snippets made that easier -- thank you for publishing them!

Users will probably want to tweak the implementation of `benchmarkHashAlgo()` to more closely align with their specific application.  (blake3 appears to perform rather poorly in this benchmark at first, though it pulls a significant lead when `h.Sum()` is called less frequently.)